### PR TITLE
버튼 전체 영역(Wrapper) 크기 수정

### DIFF
--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -40,6 +40,13 @@ const Button = ({ text, type = 'button', errorMessage, handleClick }) => {
 const Wrapper = styled.div`
   display: inline-block;
   text-align: center;
+  width: 192px;
+  height: 75px;
+
+  @media ${({ theme }) => theme.devices.DESKTOP} {
+    width: 288px;
+    height: 110px;
+  }
 `;
 
 const ButtonStyle = styled.button`
@@ -51,7 +58,7 @@ const ButtonStyle = styled.button`
   font-size: 18px;
   line-height: 23px;
 
-  @media (min-width: 1200px) {
+  @media ${({ theme }) => theme.devices.DESKTOP} {
     width: 260px;
     height: 70px;
     font-size: 28px;
@@ -72,7 +79,7 @@ const ErrorText = styled.p`
   margin-top: 10px;
   line-height: 15px;
 
-  @media (min-width: 1200px) {
+  @media ${({ theme }) => theme.devices.DESKTOP} {
     font-size: 18px;
     margin-top: 17px;
     line-height: 23px;

--- a/src/pages/ApplyInfo/index.js
+++ b/src/pages/ApplyInfo/index.js
@@ -284,7 +284,7 @@ const SubmitButtonContainer = styled.div`
   }
   @media ${({ theme }) => theme.devices.DESKTOP} {
     margin-top: 100px;
-    margin-bottom: 200px;
+    margin-bottom: 160px;
   }
 `;
 

--- a/src/pages/ApplyInfo/index.js
+++ b/src/pages/ApplyInfo/index.js
@@ -278,7 +278,7 @@ const SubmitButtonContainer = styled.div`
   width: 100%;
   justify-content: center;
   margin-top: 50px;
-  margin-bottom: 125px;
+  margin-bottom: 100px;
   @media ${({ theme }) => theme.devices.TABLET} {
     margin-top: 100px;
   }

--- a/src/pages/ApplyMain/index.js
+++ b/src/pages/ApplyMain/index.js
@@ -78,11 +78,11 @@ const PartInfoBlock = styled.div`
 const WrapApplyButton = styled.div`
   text-align: center;
   margin-top: 50px;
-  margin-bottom: 125px;
+  margin-bottom: 100px;
 
   @media ${({ theme }) => theme.devices.DESKTOP} {
     margin-top: 100px;
-    margin-bottom: 160px;
+    margin-bottom: 120px;
   }
 `;
 

--- a/src/pages/ApplyNotFound/index.js
+++ b/src/pages/ApplyNotFound/index.js
@@ -51,12 +51,12 @@ const LogoBox = styled.div`
 const ButtonBox = styled.div`
   display: flex;
   justify-content: center;
-  margin: 60px auto 146px auto;
+  margin: 60px auto 121px auto;
   @media ${({ theme }) => theme.devices.TABLET} {
-    margin: 70px auto 223px auto;
+    margin: 70px auto 198px auto;
   }
   @media ${({ theme }) => theme.devices.DESKTOP} {
-    margin: 70px auto 272px auto;
+    margin: 70px auto 232px auto;
   }
 `;
 

--- a/src/pages/ApplyWrite/index.js
+++ b/src/pages/ApplyWrite/index.js
@@ -333,12 +333,12 @@ const WriteArea = styled.textarea`
 const ButtonBox = styled.div`
   display: flex;
   justify-content: center;
-  margin: 20px auto 125px auto;
+  margin: 20px auto 100px auto;
   @media ${({ theme }) => theme.devices.TABLET} {
-    margin: 50px auto 125px auto;
+    margin: 50px auto 100px auto;
   }
   @media ${({ theme }) => theme.devices.DESKTOP} {
-    margin: 0 auto 200px auto;
+    margin: 0 auto 160px auto;
   }
 `;
 


### PR DESCRIPTION
기존 코드의 경우 초반에 버튼의 크기대로만 영역이 설정되어 있어 에러 메시지 등장 시 콘텐츠의 위치가 변동되는 이슈를 발견했습니다. 디자이너님에게 확인한 바 디자이너님이 의도한 바는 애초에 버튼 wrapper의 크기를 에러 메시지를 포함한 영역으로 확장시켜 에러 메시지가 등장해도 모든 콘텐츠의 위치 변화가 없게 하는 것이었기에 이에 맞춰 수정했습니다.
우선 지원하기 페이지에서 원유오빠랑 학수오빠가 준 margin bottom 피그마랑 비교해서 수정 후에 말씀 드릴테니까 확인 한 번씩 부탁드릴게요! @harksu @ChoiWonYu 