### PR TITLE
푸터 px 디테일 수정

### DIFF
--- a/src/components/Footer/Footer.js
+++ b/src/components/Footer/Footer.js
@@ -57,7 +57,7 @@ const FooterIconsBox = styled.div`
   display: flex;
   justify-content: space-between;
   width: 264px;
-  gap: 16px;
+  height: 40px;
   @media ${({ theme }) => theme.devices.DESKTOP} {
     width: 440px;
     height: 56px;
@@ -67,9 +67,8 @@ const FooterIconsBox = styled.div`
 const FooterRouteOfficialBox = styled.a`
   display: flex;
   align-items: center;
-  margin-top: 12px;
+  margin-top: 18px;
   margin-bottom: 18px;
-  gap: 4px;
   text-decoration: none;
   cursor: pointer;
   @media ${({ theme }) => theme.devices.TABLET} {
@@ -78,6 +77,7 @@ const FooterRouteOfficialBox = styled.a`
   @media ${({ theme }) => theme.devices.DESKTOP} {
     margin-top: 20px;
     margin-bottom: 30px;
+    gap: 5px;
   }
 `;
 
@@ -85,9 +85,7 @@ const FooterRouteOfficialBtn = styled.button`
   all: unset;
   color: ${({ theme }) => theme.colors.GRAY2};
   font-size: 12px;
-  line-height: 10px;
-  text-align: center;
-  height: 26px;
+  height: 20px;
   @media ${({ theme }) => theme.devices.DESKTOP} {
     font-size: 14px;
     height: 30px;


### PR DESCRIPTION
피그마상 푸터 공식 사이트 이동 버튼 상하 margin 수정사항 토스트 메시지 뜨는 위치 피그마와 동일하게 되게끔 px 디테일 반영 완료했습니당~!

![image](https://user-images.githubusercontent.com/90755664/220938306-bd1c66b3-0d8d-4447-ab06-6226a4199916.png)

![image](https://user-images.githubusercontent.com/90755664/220938222-69e57bcf-0292-4019-af45-67ffa26bf4f1.png)

![image](https://user-images.githubusercontent.com/90755664/220938461-0e4e6e73-a219-4bfd-b1d5-fddab23bc7aa.png)
